### PR TITLE
Updating Timestamps for Messages

### DIFF
--- a/src/api/controllers/client.webhook.controller.ts
+++ b/src/api/controllers/client.webhook.controller.ts
@@ -118,12 +118,12 @@ export class ClientWebhookController {
                 this.responseHandler.sendSuccessResponse(res, 200, 'Message sent successfully!', "");
             }
             else if (statuses[0].status === "delivered") {
-                await messageStatusRepostiory.update({ messageDeliveredTimestamp: date, messageStatus: statuses[0].status }, { where: { chatMessageId: message.id }})
+                await messageStatusRepostiory.update({ messageDeliveredTimestamp: date, messageStatus: statuses[0].status }, { where: { chatMessageId: message.id } })
                     .then(() => { Logger.instance().log("Delivered timestamp entered in the database"); });
                 this.responseHandler.sendSuccessResponse(res, 200, 'Message delivered successfully!', "");
             }
             else if (statuses[0].status === "read") {
-                await messageStatusRepostiory.update({ messageReadTimestamp: date, messageStatus: statuses[0].status }, { where: { chatMessageId: message.id }})
+                await messageStatusRepostiory.update({ messageReadTimestamp: date, messageStatus: statuses[0].status }, { where: { chatMessageId: message.id } })
                     .then(() => { Logger.instance().log("Read timestamp entered in the database"); });
                 this.responseHandler.sendSuccessResponse(res, 200, 'Message read successfully!', "");
             }

--- a/src/api/controllers/client.webhook.controller.ts
+++ b/src/api/controllers/client.webhook.controller.ts
@@ -6,6 +6,7 @@ import { platformServiceInterface } from '../../refactor/interface/platform.inte
 import { scoped, Lifecycle, inject } from 'tsyringe';
 import { clientAuthenticator } from '../../services/clientAuthenticator/client.authenticator.interface';
 import { ChatMessage } from '../../models/chat.message.model';
+import { MessageStatus } from '../../models/message.status';
 import { EntityManagerProvider } from '../../services/entity.manager.provider.service';
 import { ClientEnvironmentProviderService } from '../../services/set.client/client.environment.provider.service';
 import { ContactList } from '../../models/contact.list';
@@ -14,6 +15,7 @@ import { translateService } from '../../services/translate.service';
 import { UserConsent } from '../../models/user.consent.model';
 import { ConsentService } from '../../services/consent.service';
 import { Registration } from '../../services/registration/patient.registration.service';
+import { Logger } from '../../common/logger';
 
 @scoped(Lifecycle.ContainerScoped)
 export class ClientWebhookController {
@@ -89,23 +91,46 @@ export class ClientWebhookController {
         return consentRequired;
     }
 
-    async sendSuccessMessage(chatMessageRepository,res,statuses){
+    async sendSuccessMessage(chatMessageRepository, messageStatusRepostiory, res, statuses){
         try {
             const date = new Date(parseInt(statuses[0].timestamp) * 1000);
+            let message = await chatMessageRepository.findOne({ where: { responseMessageID: statuses[0].id } });
+
+            if (message == null){
+                await this.sleep(2000);
+                message = await chatMessageRepository.findOne({ where: { responseMessageID: statuses[0].id } });
+            }
+
+            const messageStatusObj: Partial<MessageStatus> = {
+                chatMessageId : message.id,
+                messageStatus : statuses[0].status,
+                channel       : message.platform,
+            };
             if (statuses[0].status === "sent") {
-                await chatMessageRepository.update({ whatsappResponseStatusSentTimestamp: date },{ where: { responseMessageID: statuses[0].id } })
-                    .then(() => { console.log("Sent timestamp entered in database"); });
+                messageStatusObj.messageSentTimestamp = date;
+                const messageStatus = await messageStatusRepostiory.findOne({ where: { chatMessageId: message.id } });
+                if (messageStatus) {
+                    await messageStatusRepostiory.update({ messageSentTimestamp: date, messageStatus: statuses[0].status }, { where: { chatMessageId: message.id } });
+                } else {
+                    await messageStatusRepostiory.create(messageStatusObj)
+                        .then(() => { Logger.instance().log("Send timestamp entered in the database"); });
+                }
                 this.responseHandler.sendSuccessResponse(res, 200, 'Message sent successfully!', "");
             }
             else if (statuses[0].status === "delivered") {
-                await chatMessageRepository.update({ whatsappResponseStatusDeliveredTimestamp: date },{ where: { responseMessageID: statuses[0].id } })
-                    .then(() => { console.log("Delivered timestamp of entered in database"); });
+                await messageStatusRepostiory.update({ messageDeliveredTimestamp: date, messageStatus: statuses[0].status }, { where: { chatMessageId: message.id }})
+                    .then(() => { Logger.instance().log("Delivered timestamp entered in the database"); });
                 this.responseHandler.sendSuccessResponse(res, 200, 'Message delivered successfully!', "");
             }
             else if (statuses[0].status === "read") {
-                await chatMessageRepository.update({ whatsappResponseStatusReadTimestamp: date },{ where: { responseMessageID: statuses[0].id } })
-                    .then(() => { console.log("Read timestamp of entered in database"); });
+                await messageStatusRepostiory.update({ messageReadTimestamp: date, messageStatus: statuses[0].status }, { where: { chatMessageId: message.id }})
+                    .then(() => { Logger.instance().log("Read timestamp entered in the database"); });
                 this.responseHandler.sendSuccessResponse(res, 200, 'Message read successfully!', "");
+            }
+            else if (statuses[0].status === "replied") {
+                await messageStatusRepostiory.update({ messageRepliedTimestamp: date, messageStatus: statuses[0].status }, { where: { chatMessageId: message.id } })
+                    .then(() => { Logger.instance().log("Replied timestamp entered in the database"); });
+                this.responseHandler.sendSuccessResponse(res, 200, 'Message replied successfully!', "");
             }
             else {
                 const temp = this.responseHandler.sendSuccessResponse(res, 200, 'Notification received successfully!', "");
@@ -123,6 +148,7 @@ export class ClientWebhookController {
             const clientName = clientEnvironmentProviderService.getClientEnvironmentVariable("NAME");
             const entityManagerProvider = req.container.resolve(EntityManagerProvider);
             const chatMessageRepository = (await entityManagerProvider.getEntityManager(clientEnvironmentProviderService,clientName)).getRepository(ChatMessage);
+            const messageStatusRepostiory = (await entityManagerProvider.getEntityManager(clientEnvironmentProviderService, clientName)).getRepository(MessageStatus);
             this._clientAuthenticatorService = req.container.resolve(req.params.channel + '.authenticator');
             this._clientAuthenticatorService.authenticate(req,res);
             let userPlatformId = null;
@@ -133,7 +159,7 @@ export class ClientWebhookController {
                 [userPlatformId ,platformUserName] = await this.getTelegramUserID(req.body);
             }
             if (req.body.statuses) {
-                this.sendSuccessMessage(chatMessageRepository,res,req.body.statuses);
+                this.sendSuccessMessage(chatMessageRepository, messageStatusRepostiory, res,req.body.statuses);
             }
             else {
                 const consentRequirement =  clientEnvironmentProviderService.getClientEnvironmentVariable("CONSENT_ACTIVATION");
@@ -294,11 +320,12 @@ export class ClientWebhookController {
 
     receiveMessageMetaWhatsapp = async (req, res) => {
         try {
-            const clientEnvironmentProviderService = req.container.resolve(ClientEnvironmentProviderService);
+            const clientEnvironmentProviderService = req. container.resolve(ClientEnvironmentProviderService);
             const entityManagerProvider = req.container.resolve(EntityManagerProvider);
             const clientName = clientEnvironmentProviderService.getClientEnvironmentVariable("NAME");
             console.log("clientName in webhook", clientName);
             const chatMessageRepository = (await entityManagerProvider.getEntityManager(clientEnvironmentProviderService,clientName)).getRepository(ChatMessage);
+            const messageStatusRepository = (await entityManagerProvider.getEntityManager(clientEnvironmentProviderService, clientName)).getRepository(MessageStatus);
             this._clientAuthenticatorService = req.container.resolve(req.params.channel + '.authenticator');
             this._clientAuthenticatorService.authenticate(req,res);
             const statuses = req.body.entry[0].changes[0].value.statuses;
@@ -307,7 +334,10 @@ export class ClientWebhookController {
             let userPlatformId = null;
             let platformUserName = null;
             if (statuses) {
-                this.sendSuccessMessage(chatMessageRepository,res,statuses);
+                
+                // Logs have been added to track the status will be removed in next release
+                console.log(statuses[0].status);
+                this.sendSuccessMessage(chatMessageRepository, messageStatusRepository, res,statuses);
             }
             else {
                 console.log("receiveMessage webhook receiveMessageWhatsappNew");
@@ -344,17 +374,18 @@ export class ClientWebhookController {
             const clientEnvironmentProviderService = req.container.resolve(ClientEnvironmentProviderService);
             const entityManagerProvider = req.container.resolve(EntityManagerProvider);
             const clientName = clientEnvironmentProviderService.getClientEnvironmentVariable("NAME");
+            const chatMessageRepository = (await entityManagerProvider.getEntityManager(clientEnvironmentProviderService, clientName)).getRepository(ChatMessage);
+            const messageStatusRepository = (await entityManagerProvider.getEntityManager(clientEnvironmentProviderService, clientName)).getRepository(MessageStatus);
             console.log("Wati Client Name:", clientName);
             if (req.body.statusString === "SENT" && req.body.type === "template"){
                 this.responseHandler.sendSuccessResponse(res, 200, "Sent status read", "");
                 await this.sleep(5000);
-                const chatMessageRepository = (await entityManagerProvider.getEntityManager(clientEnvironmentProviderService, clientName)).getRepository(ChatMessage);
                 const whatsappMessageId = req.body.whatsappMessageId;
                 await chatMessageRepository.update({ responseMessageID: whatsappMessageId }, { where: { responseMessageID: req.body.localMessageId } })
                     .then(() => { console.log("DB Updated with Whatsapp Response ID"); })
                     .catch(error => console.log("error on update", error));
 
-            } else if (req.body.statusString === "SENT") {
+            } else if (req.body.statusString === "SENT" && req.body.owner === false) {
                 this.responseHandler.sendSuccessResponse(res, 200, 'Message received successfully!', "");
                 this._clientAuthenticatorService = req.container.resolve(req.params.channel + '.authenticator');
                 this._clientAuthenticatorService.authenticate(req, res);
@@ -362,11 +393,17 @@ export class ClientWebhookController {
                 this._platformMessageService.handleMessage(req.body, req.params.channel);
             } else {
 
-                // Future addition
-            }
+                // Logs have been added to track the status will be removed in next release
+                console.log(req.body.statusString);
 
-            // const chatMessageRepository = (await entityManagerProvider.getEntityManager(this.clientEnvironmentProviderService, clientName)).getRepository(ChatMessage);
-            // this.sendSuccessMessage(chatMessageRepository, res, req.body.statusString);
+                // Will handle the status strings here to update in the DB
+                const statuses = [{
+                    "id"        : req.body.whatsappMessageId,
+                    "status"    : req.body.statusString.toLowerCase(),
+                    "timestamp" : req.body.timestamp,
+                }];
+                await this.sendSuccessMessage(chatMessageRepository, messageStatusRepository, res, statuses);
+            }
         } catch (error) {
             console.log("error in Wati message handler", error);
             this.errorHandler.handle_controller_error(error, res, req);

--- a/src/connection/sequelizeClient.ts
+++ b/src/connection/sequelizeClient.ts
@@ -3,6 +3,7 @@ import { autoInjectable, singleton } from 'tsyringe';
 import { ChatMessage } from '../models/chat.message.model';
 import { ChatSession } from '../models/chat.session';
 import { ContactList } from '../models/contact.list';
+import { MessageStatus } from '../models/message.status';
 import { ClientEnvironmentProviderService } from '../services/set.client/client.environment.provider.service';
 import { CalorieInfo } from '../models/calorie.info.model';
 import { CalorieDatabase } from '../models/calorie.db.model';
@@ -32,7 +33,15 @@ export class SequelizeClient {
                 // eslint-disable-next-line max-len
                 sequelizeClient.addModels([ChatMessage, ChatSession, ContactList, CalorieInfo, CalorieDatabase,ConsentInfo,UserConsent]);
             } else {
-                sequelizeClient.addModels([ChatMessage, ChatSession, ContactList, AssessmentSessionLogs,ConsentInfo,UserConsent]);
+                sequelizeClient.addModels([
+                    ChatMessage,
+                    ChatSession,
+                    ContactList,
+                    AssessmentSessionLogs,
+                    ConsentInfo,
+                    UserConsent,
+                    MessageStatus
+                ]);
             }
     
             await sequelizeClient.authenticate()

--- a/src/connection/sequelizeClient.ts
+++ b/src/connection/sequelizeClient.ts
@@ -9,7 +9,7 @@ import { CalorieInfo } from '../models/calorie.info.model';
 import { CalorieDatabase } from '../models/calorie.db.model';
 import { AssessmentSessionLogs } from '../models/assessment.session.model';
 import { ConsentInfo } from '../models/consent.info.model';
-import {UserConsent} from '../models/user.consent.model';
+import { UserConsent } from '../models/user.consent.model';
 const sequrlizeClients = new Map<string, Sequelize>();
 @autoInjectable()
 @singleton()
@@ -61,7 +61,6 @@ export class SequelizeClient {
             console.log("No DB to connect");
         }
         
-
     };
 
     // eslint-disable-next-line max-len

--- a/src/models/message.status.ts
+++ b/src/models/message.status.ts
@@ -1,0 +1,69 @@
+/* eslint-disable indent */
+import { Table, Column, Model, DataType, PrimaryKey, AutoIncrement, HasMany, ForeignKey, BelongsTo } from 'sequelize-typescript';
+import { IMessageStatus } from '../refactor/interface/message.interface';
+import { ChatMessage } from './chat.message.model';
+
+@Table(
+    {
+        timestamps: true,
+        modelName: 'MessageStatus',
+        tableName: 'message_status'
+    }
+)
+
+export class MessageStatus extends Model implements IMessageStatus {
+
+    @AutoIncrement
+    @PrimaryKey
+    @Column({
+        type    : DataType.INTEGER,
+        allowNull : false
+    })
+        autoIncrementalID?: number;
+
+    @ForeignKey(() => ChatMessage)
+    @Column({
+        type  : DataType.INTEGER,
+        allowNull : true
+    })
+        chatMessageId: number;
+
+    @BelongsTo(() => ChatMessage)
+        chatMessage: ChatMessage;
+
+    @Column({
+        type: DataType.STRING(256),
+        allowNull: true
+    })
+        channel: string;
+
+    @Column({
+        type: DataType.STRING(256),
+        allowNull: true
+    })
+        messageStatus: string;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: true
+    })
+        messageSentTimestamp: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: true
+    })
+        messageDeliveredTimestamp: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: true
+    })
+        messageReadTimestamp: Date;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: true
+    })
+        messageRepliedTimestamp: Date;
+}

--- a/src/models/message.status.ts
+++ b/src/models/message.status.ts
@@ -1,13 +1,13 @@
 /* eslint-disable indent */
-import { Table, Column, Model, DataType, PrimaryKey, AutoIncrement, HasMany, ForeignKey, BelongsTo } from 'sequelize-typescript';
+import { Table, Column, Model, DataType, PrimaryKey, AutoIncrement, ForeignKey, BelongsTo } from 'sequelize-typescript';
 import { IMessageStatus } from '../refactor/interface/message.interface';
 import { ChatMessage } from './chat.message.model';
 
 @Table(
     {
-        timestamps: true,
-        modelName: 'MessageStatus',
-        tableName: 'message_status'
+        timestamps : true,
+        modelName : 'MessageStatus',
+        tableName : 'message_status'
     }
 )
 
@@ -32,38 +32,39 @@ export class MessageStatus extends Model implements IMessageStatus {
         chatMessage: ChatMessage;
 
     @Column({
-        type: DataType.STRING(256),
-        allowNull: true
+        type : DataType.STRING(256),
+        allowNull : true
     })
         channel: string;
 
     @Column({
-        type: DataType.STRING(256),
-        allowNull: true
+        type : DataType.STRING(256),
+        allowNull : true
     })
         messageStatus: string;
 
     @Column({
-        type: DataType.DATE,
-        allowNull: true
+        type : DataType.DATE,
+        allowNull : true
     })
         messageSentTimestamp: Date;
 
     @Column({
-        type: DataType.DATE,
-        allowNull: true
+        type : DataType.DATE,
+        allowNull : true
     })
         messageDeliveredTimestamp: Date;
 
     @Column({
-        type: DataType.DATE,
-        allowNull: true
+        type : DataType.DATE,
+        allowNull : true
     })
         messageReadTimestamp: Date;
 
     @Column({
-        type: DataType.DATE,
-        allowNull: true
+        type : DataType.DATE,
+        allowNull : true
     })
         messageRepliedTimestamp: Date;
+    
 }

--- a/src/refactor/interface/message.interface.ts
+++ b/src/refactor/interface/message.interface.ts
@@ -102,6 +102,17 @@ export interface contactList {
     optOut?: string;
 }
 
+export interface IMessageStatus {
+    autoIncrementalID?: number;
+    chatMessageId: number;
+    channel: string;
+    messageStatus: string;
+    messageSentTimestamp: Date;
+    messageDeliveredTimestamp: Date;
+    messageReadTimestamp: Date;
+    messageRepliedTimestamp: Date;
+}
+
 export interface IprocessedDialogflowResponseFormat{
     processed_message: any;
     message_from_nlp: IserviceResponseFunctionalities;


### PR DESCRIPTION
### Details of Feature/Bug
  - Message status tracking
  - A new table has been added to track the status of the messages, i.e status string, and sent, delivered, read and replied timestamps. This feature is developed for only Wati and Whatsapp Meta and not for any other channel at the moment.
  
### List of changes
  - Added new model messageStatus
  - Changes to send success response function in client webhook controller

### Database migration/schema changes (if any)
- New table added but does not require any migrations for now

### Self review checklist
  - [x] Ran all the tests locally to check that you have not introduced any new regression. 
  - [x] Followed coding and styling guidelines. Checked for ESLint fixes.
  - [x] Checked for any dependencies and updated them.
  - [x] Made sure to add the comments where required.
  - [x] Added the PR link to the ticket assigned. 
  - [x] Make sure you have updated (if necessary)-
    - [x] Documentation (if any)
    - [x] Noted version number
    - [x] Added the label in the PR
    - [x] Created release notes
       
### Additional info (if any)
- *Add anything you feel worth mentioning...*
