### PR TITLE
Location message changes

### DIFF
--- a/src/services/telegram.message.service.functionalities.ts
+++ b/src/services/telegram.message.service.functionalities.ts
@@ -81,7 +81,7 @@ export class TelegramMessageServiceFunctionalities implements getMessageFunction
 
     async locationMessageFormat(messageObj: Message) {
         const messagetoDialogflow = this.inputMessageFormat(messageObj);
-        const location_message = `latlong:${messageObj.getLocation().latitude}-${messageObj.getLocation().longitude}`;
+        const location_message = `latlong:${messageObj.getLocation().latitude}|${messageObj.getLocation().longitude}`;
         messagetoDialogflow.type = 'location';
         messagetoDialogflow.latlong = messageObj.getLocation();
         messagetoDialogflow.messageBody = location_message;

--- a/src/services/whatsapp.functionalities.ts
+++ b/src/services/whatsapp.functionalities.ts
@@ -48,7 +48,7 @@ export class MessageFunctionalities implements getMessageFunctionalities {
 
     async locationMessageFormat (messageObj: Message) {
         const messagetoDialogflow = this.inputMessageFormat(messageObj);
-        const loc = `latlong:${messageObj.getLocation().latitude}-${messageObj.getLocation().longitude}`;
+        const loc = `latlong:${messageObj.getLocation().latitude}|${messageObj.getLocation().longitude}`;
         messagetoDialogflow.type = 'location';
         messagetoDialogflow.latlong = messageObj.getLocation();
         messagetoDialogflow.messageBody = loc;


### PR DESCRIPTION
- Replaced - as the separator and added | because there might be negative lat and long

### Details of Feature/Bug
  - Location pin giving wrong lat-longs
  - As there are chances of lat-longs to be negative, the seprator - is causing issue while fetching the lat longs.
  
### List of changes
  - The sperator is changed to | from - to handle these scenarios better.

### Database migration/schema changes (if any)
- N/A

### Self review checklist
  - [x] Ran all the tests locally to check that you have not introduced any new regression. 
  - [x] Followed coding and styling guidelines. Checked for ESLint fixes.
  - [x] Checked for any dependencies and updated them.
  - [x] Made sure to add the comments where required.
  - [x] Added the PR link to the ticket assigned. 
  - [x] Make sure you have updated (if necessary)-
    - [x] Documentation (if any)
    - [x] Noted version number
    - [x] Added the label in the PR
    - [x] Created release notes
       
### Additional info (if any)
- *Add anything you feel worth mentioning...*
