### PR TITLE
Updates for fixed message language

### DIFF
--- a/src/services/feedback/feedback.service.ts
+++ b/src/services/feedback/feedback.service.ts
@@ -78,7 +78,12 @@ export  class FeedbackService implements feedbackInterface {
                         await this.supportChannel(preferredSupportChannel,responseChatMessage,messageContent,topic,"Negative Feedback");
                     }
                     if (await humanHandoff.checkTime() === "false"){
-                        const reply = "We're genuinely sorry to hear that you weren't satisfied with the assistance provided by our chatbot. Your feedback is invaluable in helping us improve our services. our team of experts will provide you with a satisfactory resolution as quickly as possible.";
+                        let reply = "";
+                        if (clientEnvironmentProviderService.getClientEnvironmentVariable("NEGATIVE_FEEDBACK_MESSAGE")) {
+                            reply = clientEnvironmentProviderService.getClientEnvironmentVariable("NEGATIVE_FEEDBACK_MESSAGE");
+                        } else {
+                            reply = "We're genuinely sorry to hear that you weren't satisfied with the assistance provided by our chatbot. Your feedback is invaluable in helping us improve our services. our team of experts will provide you with a satisfactory resolution as quickly as possible.";
+                        }
                         const data = {
                             "fulfillmentMessages" : [
                                 {

--- a/src/services/handle.request.service.ts
+++ b/src/services/handle.request.service.ts
@@ -145,16 +145,21 @@ export class handleRequestservice {
             break;
         }
         case 'Feedback': {
-            let message_to_ml_model = null;
+            let messageToMlModel = null;
             if (metaData.contextId && !metaData.intent) {
                 let tag = "null";
                 tag = (metaData.type === "reaction") ? "reaction" : "Feedback";
                 await this.feedbackService.recordFeedback(outgoingMessage.Feedback.FeedbackContent, metaData.contextId, tag);
-                message_to_ml_model = "I have sent feedback to your message tell me that : we have achnowlwged your feedback out team of experts will come back to you";
-                message_from_nlp = await this.customMLModelResponseService.getCustomModelResponse(message_to_ml_model, metaData.platform, metaData);
+                if (this.clientEnvironmentProviderService.getClientEnvironmentVariable("FEEDBACK_PROMPT")) {
+                    const feedbackPrompt = this.clientEnvironmentProviderService.getClientEnvironmentVariable("FEEDBACK_PROMPT");
+                    messageToMlModel = feedbackPrompt + outgoingMessage.Feedback.FeedbackContent;
+                } else {
+                    messageToMlModel = "I have sent feedback to your message tell me that : we have acknowledged your feedback out team of experts will come back to you";
+                }
+                message_from_nlp = await this.customMLModelResponseService.getCustomModelResponse(messageToMlModel, metaData.platform, metaData);
             } else {
-                message_to_ml_model = outgoingMessage.Feedback.FeedbackContent;
-                message_from_nlp = await this.DialogflowResponseService.getDialogflowMessage(message_to_ml_model, metaData.platform, metaData.intent, metaData);
+                messageToMlModel = outgoingMessage.Feedback.FeedbackContent;
+                message_from_nlp = await this.DialogflowResponseService.getDialogflowMessage(messageToMlModel, metaData.platform, metaData.intent, metaData);
             }
             break;
         }

--- a/src/services/response.format/custom.model.response.format.ts
+++ b/src/services/response.format/custom.model.response.format.ts
@@ -30,9 +30,11 @@ export class CustomModelResponseFormat implements IserviceResponseFunctionalitie
 
         //get intent
         let intent;
-        if (this.response.body && this.response.body.source_of_info){
-            intent = this.response.body.intent + '|' + this.response.body.source_of_info;
-        } else if (this.response.body && !this.response.body.source_of_info){
+        // if (this.response.body && this.response.body.source_of_info){
+        //     intent = this.response.body.intent + '|' + this.response.body.source_of_info;
+        // } else if (this.response.body && !this.response.body.source_of_info){
+        //     intent = this.response.body.intent;
+        if (this.response.body) {
             intent = this.response.body.intent;
         } else {
             intent = "Failed Intent";

--- a/src/services/translate.service.ts
+++ b/src/services/translate.service.ts
@@ -93,7 +93,7 @@ export class translateService{
         const intent = messageFromDialogflow.getIntent();
         const parse_mode = messageFromDialogflow.getParseMode();
         const text = messageFromDialogflow.getText();
-        const customTranslateSetting = this.clientEnvironmentProviderService.getClientEnvironmentVariable("FIX_LANGUAGE");
+        const customTranslateSetting: boolean = this.clientEnvironmentProviderService.getClientEnvironmentVariable("FIX_LANGUAGE") === "true";
         const listOfNoTranslateIntents = this.clientEnvironmentProviderService.getClientEnvironmentVariable("FIX_LANGUAGE_INTENTS") ?? [];
         if (parse_mode) {
             translatedResponse = text;

--- a/src/services/translate.service.ts
+++ b/src/services/translate.service.ts
@@ -90,12 +90,16 @@ export class translateService{
         console.log("entered the processdialogflowmessage of translateService JJJJJJJJJJJ");
         // eslint-disable-next-line init-declarations
         let translatedResponse;
+        const intent = messageFromDialogflow.getIntent();
         const parse_mode = messageFromDialogflow.getParseMode();
         const text = messageFromDialogflow.getText();
+        const customTranslateSetting = this.clientEnvironmentProviderService.getClientEnvironmentVariable("FIX_LANGUAGE");
+        const listOfNoTranslateIntents = this.clientEnvironmentProviderService.getClientEnvironmentVariable("FIX_LANGUAGE_INTENTS") ?? [];
         if (parse_mode) {
             translatedResponse = text;
-        }
-        else {
+        } else if (listOfNoTranslateIntents.includes(intent) && customTranslateSetting){
+            translatedResponse = text;
+        } else {
             translatedResponse = await this.translateResponse(text, detected_language);
         }
         return translatedResponse;


### PR DESCRIPTION
- Enabled the service to pick from the config file to fix the language of intents.
- For feedback messages, the text can now be added to the config file
- For the positive feedback prompt can also be set in the config file

### Details of Feature/Bug
  - Fix the language of certain messages immaterial of the user input language.
  - Clients may require the welcome message to be sent in a fixed language only. This is only for a particular message and not the should not effect the default language of the user.
  
### List of changes
  - Added 4 new config variables that are customizable
    - NEGATIVE_FEEDBACK_MESSAGE | TEXT: This is the text to be sent when negative feedback is given
    - FEEDBACK_PROMPT | TEXT: This is the prompt being sent to the llm for positive feedbacks
    - FIX_LANGUAGE | BOOL : flag to enable the fixed language for messages
    - FIX_LANGUAGE_INTENTS | [TEXT] : Intents which need no translation can be added here
  - 

### Database migration/schema changes (if any)
- None

### Self review checklist
  - [x] Ran all the tests locally to check that you have not introduced any new regression. 
  - [x] Followed coding and styling guidelines. Checked for ESLint fixes.
  - [x] Checked for any dependencies and updated them.
  - [x] Made sure to add the comments where required.
  - [x] Added the PR link to the ticket assigned. 
  - [x] Make sure you have updated (if necessary)-
    - [x] Documentation (if any)
    - [x] Noted version number
    - [x] Added the label in the PR
    - [x] Created release notes
       
### Additional info (if any)
- *Add anything you feel worth mentioning...*
