### PR TITLE
Adding tags to clickup Tasks

### DIFF
--- a/src/services/clickup/clickup.task.ts
+++ b/src/services/clickup/clickup.task.ts
@@ -149,5 +149,25 @@ export class ClickUpTask{
         }
         
     }
+
+    async updateTag(taskID: string, intent = '') {
+        try {
+            const clientTags = JSON.parse(this.clientEnvironmentProviderService.getClientEnvironmentVariable("CLICKUP_TAGS"));
+            if (clientTags) {
+                const exists = clientTags.includes(intent);
+                if (exists) {
+                    const updateTaskUrl = `https://api.clickup.com/api/v2/task/${taskID}/tag/${intent}`;
+                    const options = getRequestOptions();
+                    const CLICKUP_AUTHENTICATION = this.clientEnvironmentProviderService.getClientEnvironmentVariable("CLICKUP_AUTHENTICATION");
+                    options.headers["Authorization"] =  CLICKUP_AUTHENTICATION;
+                    options.headers["Content-Type"] = `application/json`;
+                    const response = await needle("post", updateTaskUrl, {}, options);
+                    console.log(response);
+                }
+            }
+        } catch (error) {
+            console.log("Error while updating the clickup tags.");
+        }
+    }
     
 }

--- a/src/services/logs.for.qa.ts
+++ b/src/services/logs.for.qa.ts
@@ -43,7 +43,7 @@ export class LogsQAService {
             messageContentIn = responseChatMessage[responseChatMessage.length - 1].messageContent;
             let taskId = await this.postingOnClickup(`Client : ` + messageContentIn,  cmrTaskID , responseChatMessage, userName);
             const messageContentOut = response_format.messageText;
-            taskId = await this.postingOnClickup(`Bot : ` + messageContentOut + `\nIntent Name : ${response_format.intent}`, taskId, responseChatMessage, userName);
+            taskId = await this.postingOnClickup(`Bot : ` + messageContentOut + `\nIntent Name : ${response_format.intent}`, taskId, responseChatMessage, userName, response_format.intent);
             await contactList.update({
                 cmrChatTaskID : taskId
             },
@@ -56,18 +56,20 @@ export class LogsQAService {
         }
     }
 
-    async postingOnClickup(comment,cmrTaskId, responseChatMessage, userName){
-
+    async postingOnClickup(comment,cmrTaskId, responseChatMessage, userName, intent=''){
+        intent = intent.toLocaleLowerCase();
         if (cmrTaskId){
             // eslint-disable-next-line max-len
             await this.clickUpTask.postCommentOnTask(cmrTaskId,comment);
-            await this.clickUpTask.updateTask(cmrTaskId,null,null,userName);
+            await this.clickUpTask.updateTask(cmrTaskId,null,null,userName, intent);
+
+            await this.clickUpTask.updateTag(cmrTaskId, intent);
             console.log("Updating old clickUp task");
             return cmrTaskId;
         }
         else
         {
-            const taskID = await this.clickUpTask.createTask(responseChatMessage, userName, null, null);
+            const taskID = await this.clickUpTask.createTask(responseChatMessage, userName, null, null, intent);
             await this.clickUpTask.postCommentOnTask(taskID,comment);
             console.log("Creating new clickUp task");
             return taskID;


### PR DESCRIPTION
### Details of Feature/Bug
  - Add tags to clickup Tasks based on category of message.
  - Tags to be added to clickup tasks for filtering
  
### List of changes
  - Added the function to add tags to clickup tasks
  - Two new config variables added
     -  CLICKUP_TAGS : to check if tags are present or not, if not then the tags won't be added
     - BLOCK_TASK_CLOSE_MESSAGE: This is to not send the message to user when a clickup task is closed

### Database migration/schema changes (if any)
- None

### Self review checklist
  - [ ] Ran all the tests locally to check that you have not introduced any new regression. 
  - [ ] Followed coding and styling guidelines. Checked for ESLint fixes.
  - [ ] Checked for any dependencies and updated them.
  - [ ] Made sure to add the comments where required.
  - [ ] Added the PR link to the ticket assigned. 
  - [ ] Make sure you have updated (if necessary)-
    - [ ] Documentation (if any)
    - [ ] Noted version number
    - [ ] Added the label in the PR
    - [ ] Created release notes
       
### Additional info (if any)
- *Add anything you feel worth mentioning...*
