### PR TITLE
Other language assessment support

### DIFF
--- a/src/refactor/interface/message.interface.ts
+++ b/src/refactor/interface/message.interface.ts
@@ -15,6 +15,7 @@ export interface Imessage{
     intent           : string;
     responseMessageID: string;
     contextId        : string;
+    originalMessage ?: string;
 }
 
 export interface Iresponse{
@@ -178,6 +179,7 @@ export interface AssessmentDetails {
     Question       ?: string;
     Hint           ?: string;
     UserResponse   ?: string | number | boolean | unknown;
+    AssessmentFlag ?: boolean;
 }
 
 export interface Feedback {

--- a/src/services/Assesssment/assessment.service.ts
+++ b/src/services/Assesssment/assessment.service.ts
@@ -203,7 +203,7 @@ export class AssessmentService {
                 flag = options?.length
                     ? options.some(
                         (option) =>
-                            option.ProviderGivenCode.toLowerCase() === messageBody.messageBody.toLowerCase()
+                            option.ProviderGivenCode.toLowerCase() === messageBody.originalMessage.toLowerCase()
                     )
                     : false;
                 break;

--- a/src/services/get.put.message.flow.service.ts
+++ b/src/services/get.put.message.flow.service.ts
@@ -113,6 +113,7 @@ export class MessageFlow{
             const translate_message = await this.translate.translateMessage(message.type, message.messageBody, message.platformId);
             translate_message["original_message"] = message.messageBody;
             message.messageBody = translate_message.message;
+            message.originalMessage = message.messageBody;
             return { message, translate_message };
         } catch (error) {
             console.log(error);

--- a/src/services/maternalCareplan/serveAssessment/serveAssessment.service.ts
+++ b/src/services/maternalCareplan/serveAssessment/serveAssessment.service.ts
@@ -233,6 +233,8 @@ export class ServeAssessmentService {
             } else if (requestBody.Data.AnswerResponse.Next !== null && nodeType === "Message") {
                 messageFlag = "endassessment";
                 message = requestBody.Data.AnswerResponse.Next.Description;
+                const key = `${assessmentSession.userPlatformId}:NextQuestionFlag`;
+                CacheMemory.set(key, false);
             } else {
                 messageFlag = "endassessment";
                 const key = `${assessmentSession.userPlatformId}:NextQuestionFlag`;


### PR DESCRIPTION
### Details of Feature/Bug
  - Assessment in different languages are failing validation step
  - The assessment answers on single choice questions are being compared to the translated text from the buttons
  
### List of changes
  - Assessment validation is done on the original message body rather than translated message body when Assessment flag is true.

### Database migration/schema changes (if any)
- *List your migrations here...*

### Self review checklist
  - [ ] Ran all the tests locally to check that you have not introduced any new regression. 
  - [ ] Followed coding and styling guidelines. Checked for ESLint fixes.
  - [ ] Checked for any dependencies and updated them.
  - [ ] Made sure to add the comments where required.
  - [ ] Added the PR link to the ticket assigned. 
  - [ ] Make sure you have updated (if necessary)-
    - [ ] Documentation (if any)
    - [ ] Noted version number
    - [ ] Added the label in the PR
    - [ ] Created release notes
       
### Additional info (if any)
- *Add anything you feel worth mentioning...*
