### PR TITLE
Sensitivity flag check

### DIFF
--- a/src/services/clickup/clickup.task.ts
+++ b/src/services/clickup/clickup.task.ts
@@ -130,7 +130,6 @@ export class ClickUpTask{
             options.headers["Content-Type"] = `application/json`;
             const obj = {
                 "status"               : "TO DO",
-                "priority"             : priority,
                 "due_date"             : null,
                 "due_date_time"        : false,
                 "start_date_time"      : false,
@@ -140,7 +139,10 @@ export class ClickUpTask{
                 "tags"                 : [tag],
                 "markdown_description" : user_details,
                 "name"                 : topic
-            };
+            } as any;
+            if (priority != null) {
+                obj.priority = priority;
+            }
     
             await needle("put", updateTaskUrl, obj, options);
         }
@@ -188,7 +190,6 @@ export class ClickUpTask{
         try {
             const getTaskUrl = `https://api.clickup.com/api/v2/task/${taskID}`;
             const options = getRequestOptions();
-            options.json = true;
             const CLICKUP_AUTHENTICATION = this.clientEnvironmentProviderService.getClientEnvironmentVariable("CLICKUP_AUTHENTICATION");
             options.headers["Authorization"] = CLICKUP_AUTHENTICATION;
             options.headers["Content-Type"] = "application/json";

--- a/src/services/clickup/clickup.task.ts
+++ b/src/services/clickup/clickup.task.ts
@@ -183,5 +183,29 @@ export class ClickUpTask{
             console.log("Error while updating the clickup tags.");
         }
     }
-    
+
+    async getTaskPriority(taskID: string): Promise<number | null> {
+        try {
+            const getTaskUrl = `https://api.clickup.com/api/v2/task/${taskID}`;
+            const options = getRequestOptions();
+            options.json = true;
+            const CLICKUP_AUTHENTICATION = this.clientEnvironmentProviderService.getClientEnvironmentVariable("CLICKUP_AUTHENTICATION");
+            options.headers["Authorization"] = CLICKUP_AUTHENTICATION;
+            options.headers["Content-Type"] = "application/json";
+
+            const response = await needle("get", getTaskUrl, options);
+
+            if (response.statusCode !== 200) {
+                console.log("Error fetching task from ClickUp", response.body);
+                return null;
+            }
+
+            const priority = response.body?.priority?.id;
+            return priority ? Number(priority) : null;
+        } catch (error) {
+            console.log("Error while fetching task priority from ClickUp", error);
+            return null;
+        }
+    }
+
 }

--- a/src/services/logs.for.qa.ts
+++ b/src/services/logs.for.qa.ts
@@ -69,11 +69,16 @@ export class LogsQAService {
         if (cmrTaskId){
             // eslint-disable-next-line max-len
             await this.clickUpTask.postCommentOnTask(cmrTaskId,comment);
-            let sensitivity_value = null;
+            let sensitivityValue = null;
+            let prevSensitivityValue = null;
             if (sensitivity){
-                sensitivity_value = await this.sensitivityMapper(sensitivity);
+                sensitivityValue = await this.sensitivityMapper(sensitivity);
+                prevSensitivityValue = await this.clickUpTask.getTaskPriority(cmrTaskId);
+                if (sensitivityValue && prevSensitivityValue && sensitivityValue < prevSensitivityValue) {
+                    sensitivityValue = prevSensitivityValue;
+                }
             }
-            await this.clickUpTask.updateTask(cmrTaskId,sensitivity_value,description,userName, intent);
+            await this.clickUpTask.updateTask(cmrTaskId,sensitivityValue,description,userName, intent);
             await this.clickUpTask.updateTag(cmrTaskId, intent);
             console.log("Updating old clickUp task");
             return cmrTaskId;

--- a/src/services/logs.for.qa.ts
+++ b/src/services/logs.for.qa.ts
@@ -74,7 +74,7 @@ export class LogsQAService {
             if (sensitivity){
                 sensitivityValue = await this.sensitivityMapper(sensitivity);
                 prevSensitivityValue = await this.clickUpTask.getTaskPriority(cmrTaskId);
-                if (sensitivityValue && prevSensitivityValue && sensitivityValue < prevSensitivityValue) {
+                if (sensitivityValue && prevSensitivityValue && sensitivityValue > prevSensitivityValue) {
                     sensitivityValue = prevSensitivityValue;
                 }
             }


### PR DESCRIPTION
### Details of Feature/Bug
  - Sensitivity flag changes
  - For sensitivity flag updation on clickup, the value should not change if the newer conversation has a lower value for sensitivity as compared to the previouus one.
  - *Dependencies (if any)*
  
### List of changes
  - Added a method to get the priority set for a clickup task to clickup functionalities
  - Made changes to avoid priority change in case of lower priority coming in for new conversation.
  - modified updateTask method to only send priority if its not null.

### Database migration/schema changes (if any)
- *List your migrations here...*

### Self review checklist
  - [ ] Ran all the tests locally to check that you have not introduced any new regression. 
  - [ ] Followed coding and styling guidelines. Checked for ESLint fixes.
  - [ ] Checked for any dependencies and updated them.
  - [ ] Made sure to add the comments where required.
  - [ ] Added the PR link to the ticket assigned. 
  - [ ] Make sure you have updated (if necessary)-
    - [ ] Documentation (if any)
    - [ ] Noted version number
    - [ ] Added the label in the PR
    - [ ] Created release notes
       
### Additional info (if any)
- *Add anything you feel worth mentioning...*
