### PR TITLE
feat: make DB dialect + port configurable for Postgres

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "node-telegram-bot-api": "^0.54.0",
         "pb-util": "^1.0.3",
         "pdfkit": "^0.13.0",
+        "redis": "^4.7.1",
         "reflect-metadata": "^0.1.13",
         "rimraf": "3.0.2",
         "sequelize": "^6.29.3",
@@ -2597,6 +2598,65 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3069,6 +3129,7 @@
       "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
@@ -3083,6 +3144,7 @@
       "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3148,6 +3210,7 @@
       "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "@smithy/types": "^2.12.0",
@@ -3167,6 +3230,7 @@
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3180,6 +3244,7 @@
       "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3193,6 +3258,7 @@
       "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3206,6 +3272,7 @@
       "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
@@ -3220,6 +3287,7 @@
       "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -3761,7 +3829,6 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -3796,7 +3863,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3996,8 +4062,7 @@
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "15.0.20",
@@ -4103,7 +4168,6 @@
       "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",
@@ -4293,7 +4357,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5431,6 +5494,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/codepage": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
@@ -6426,7 +6498,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -6568,7 +6639,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6980,7 +7050,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7604,6 +7673,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/get-caller-file": {
@@ -8688,7 +8766,6 @@
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -10671,7 +10748,6 @@
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.16.0.tgz",
       "integrity": "sha512-AEGW7QLLSuSnjCS4pk3EIqOmogegmze9h8EyrndavUQnIUcfkVal/sK7QznE+a3bc6rzPbAiui9Jcb+96tPwYA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
         "denque": "^2.1.0",
@@ -11561,7 +11637,6 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -12007,12 +12082,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -13926,7 +14017,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14634,7 +14724,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "node-telegram-bot-api": "^0.54.0",
     "pb-util": "^1.0.3",
     "pdfkit": "^0.13.0",
+    "redis": "^4.7.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "3.0.2",
     "sequelize": "^6.29.3",

--- a/src/connection/sequelizeClient.ts
+++ b/src/connection/sequelizeClient.ts
@@ -41,8 +41,8 @@ export class SequelizeClient {
             const dbHost = process.env.DB_HOST;
             const sequelizeClient = new Sequelize(dbName, dbUser, dbPassword, {
                 host           : dbHost,
-                dialect        : 'mysql',
-                port           : 3306,
+                dialect        : (process.env.DB_DIALECT || 'mysql') as any,
+                port           : process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 3306,
                 logging        : false,
                 repositoryMode : true
             });

--- a/src/modules/cache/redis.cache.ts
+++ b/src/modules/cache/redis.cache.ts
@@ -1,367 +1,148 @@
-// import { createClient, type RedisClientType } from 'redis';
-// import type { ICache } from './cache.interface';
-// import type { CacheConfig, CacheEntry, CacheMetrics, CacheOptions } from './cache.types';
+import { createClient } from 'redis';
+import type { ICache } from './cache.interface';
+import type { CacheEntry, CacheMetrics, CacheOptions } from './cache.types';
 
-// export class RedisCache implements ICache {
-//   private _client: RedisClientType | null = null;
-//   private metrics: CacheMetrics;
-//   private config: CacheConfig;
-//   private isConnected = false;
+///////////////////////////////////////////////////////////////////////////////
 
-//   constructor(config: Partial<CacheConfig> = {}) {
-//     this.config = {
-//       DefaultTTL: 5 * 60 * 1000, // 5 minutes
-//       MaxMemorySize: 100 * 1024 * 1024, // 100MB
-//       EnableMetrics: true,
-//       EnableCompression: false,
-//       CompressionThreshold: 1024,
-//       CleanupInterval: 5 * 60 * 1000, // 5 minutes
-//       ...config
-//     };
+// Redis-backed cache used when CACHE_PROVIDER=redis. Designed to be safe:
+//  - bounded connect (won't hang startup if Redis is unreachable),
+//  - fail-open (any error degrades to a miss / no-op rather than throwing),
+//  - honours the "persistent" strategy (Ttl null/0 => stored WITHOUT expiry, so
+//    per-tenant bot-secrets survive — a fixed TTL here would silently drop them).
+export class RedisCache implements ICache {
 
-//     this.metrics = {
-//       Hits: 0,
-//       Misses: 0,
-//       HitRate: 0,
-//       TotalSize: 0,
-//       TotalEntries: 0,
-//       OldestEntry: Date.now(),
-//       NewestEntry: Date.now(),
-//       AverageEntrySize: 0
-//     };
+    private client: ReturnType<typeof createClient>;
 
-//     this.initializeClient();
-//   }
+    private connectPromise: Promise<unknown>;
 
-//   private async initializeClient(): Promise<void> {
-//     try {
-//       const port = process.env.CACHE_PORT ? parseInt(process.env.CACHE_PORT) : 6379;
-//       this._client = createClient({
-//         socket: {
-//           host: process.env.CACHE_HOST || 'localhost',
-//           port: port,
-//         },
-//         password: process.env.CACHE_PASSWORD
-//       });
+    private metrics: CacheMetrics = {
+        Hits             : 0,
+        Misses           : 0,
+        HitRate          : 0,
+        TotalSize        : 0,
+        TotalEntries     : 0,
+        OldestEntry      : Date.now(),
+        NewestEntry      : Date.now(),
+        AverageEntrySize : 0
+    };
 
-//       this._client.on('error', (err) => {
-//         console.error('Redis client error:', err);
-//         this.isConnected = false;
-//       });
+    constructor() {
+        const host = process.env.CACHE_HOST || 'localhost';
+        const port = process.env.CACHE_PORT ? parseInt(process.env.CACHE_PORT, 10) : 6379;
+        this.client = createClient({
+            socket : {
+                host,
+                port,
+                connectTimeout   : 8000,
+                // Give up after a few attempts so connect() rejects instead of retrying
+                // forever — keeps startup from hanging when Redis is down.
+                reconnectStrategy : (retries: number) =>
+                    (retries > 5 ? new Error('redis unavailable') : Math.min(retries * 200, 2000))
+            },
+            password : process.env.CACHE_PASSWORD || undefined
+        });
+        this.client.on('error', (err) => console.error('Redis cache error:', err?.message || err));
+        this.client.on('ready', () => console.log(`Redis cache connected: ${host}:${port}`));
+        this.connectPromise = this.client.connect().catch(
+            (e) => console.error('Redis cache initial connect failed (continuing in-process):', e?.message || e)
+        );
+    }
 
-//       this._client.on('connect', () => {
-//         console.log('Redis client connected');
-//         this.isConnected = true;
-//       });
+    // Await the initial connection once, then report whether the socket is open.
+    private async ready(): Promise<boolean> {
+        try { await this.connectPromise; } catch { /* logged in ctor */ }
+        return this.client.isOpen;
+    }
 
-//       this._client.on('disconnect', () => {
-//         console.log('Redis client disconnected');
-//         this.isConnected = false;
-//       });
+    async set(key: string, value: any, options: CacheOptions = {}): Promise<void> {
+        if (!(await this.ready())) return;
+        try {
+            const ttl = options.Ttl;   // null/undefined for the "persistent" strategy
+            const entry: CacheEntry = {
+                Data      : value,
+                Timestamp : Date.now(),
+                Ttl       : (ttl ?? null) as any,
+                Hits      : 0,
+                Size      : this.calculateSize(value)
+            };
+            const payload = JSON.stringify(entry);
+            if (ttl && ttl > 0) {
+                await this.client.set(key, payload, { PX: ttl });
+            } else {
+                await this.client.set(key, payload);   // persistent — no expiry
+            }
+            this.metrics.NewestEntry = entry.Timestamp;
+        } catch (error) {
+            console.error('Redis set error:', error);
+        }
+    }
 
-//       await this._client.connect();
-//     } catch (error) {
-//       console.error('Failed to initialize Redis client:', error);
-//       this.isConnected = false;
-//     }
-//   }
+    async get(key: string): Promise<CacheEntry | undefined> {
+        if (!(await this.ready())) { this.metrics.Misses++; return undefined; }
+        try {
+            const raw = await this.client.get(key);
+            if (!raw) { this.metrics.Misses++; return undefined; }
+            this.metrics.Hits++;
+            return JSON.parse(raw) as CacheEntry;
+        } catch (error) {
+            console.error('Redis get error:', error);
+            this.metrics.Misses++;
+            return undefined;
+        }
+    }
 
-//   async set(key: string, value: any, options: CacheOptions = {}): Promise<void> {
-//     if (!this._client || !this.isConnected) {
-//       console.warn('Redis client not connected');
-//       return;
-//     }
+    async has(key: string): Promise<boolean> {
+        if (!(await this.ready())) return false;
+        try { return (await this.client.exists(key)) === 1; } catch { return false; }
+    }
 
-//     try {
-//       const ttl = Math.floor((options.Ttl || this.config.DefaultTTL) / 1000); // Redis uses seconds
-//       const timestamp = Date.now();
-//       const size = this.calculateSize(value);
+    async delete(key: string): Promise<boolean> {
+        if (!(await this.ready())) return false;
+        try { return (await this.client.del(key)) > 0; } catch { return false; }
+    }
 
-//       const entry: CacheEntry = {
-//         Data: value,
-//         Timestamp: timestamp,
-//         Ttl: options.Ttl || this.config.DefaultTTL,
-//         Hits: 0,
-//         Size: size,
-//       };
+    async clear(): Promise<void> {
+        if (!(await this.ready())) return;
+        try { await this.client.flushDb(); } catch (error) { console.error('Redis clear error:', error); }
+    }
 
-//       // Store the entry as JSON
-//       const entryString = JSON.stringify(entry);
+    async findAndClear(searchPattern: string): Promise<string[]> {
+        if (!(await this.ready())) return [];
+        try {
+            const keys = await this.client.keys(`*${searchPattern}*`);
+            if (keys.length > 0) { await this.client.del(keys); }
+            return keys;
+        } catch (error) {
+            console.error('Redis findAndClear error:', error);
+            return [];
+        }
+    }
 
-//       // Check if key exists for metrics
-//       const exists = await this._client.exists(key);
-//       if (exists === 1) {
-//         const oldEntry = await this.get(key);
-//         if (oldEntry) {
-//           this.updateMetrics(oldEntry, 'remove');
-//         }
-//       }
+    async getMetrics(): Promise<CacheMetrics> {
+        const total = this.metrics.Hits + this.metrics.Misses;
+        this.metrics.HitRate = total > 0 ? this.metrics.Hits / total : 0;
+        try { if (await this.ready()) { this.metrics.TotalEntries = await this.client.dbSize(); } } catch { /* ignore */ }
+        return { ...this.metrics };
+    }
 
-//       await this._client.setEx(key, ttl, entryString);
-//       this.updateMetrics(entry, 'add');
+    async cleanup(): Promise<void> {
+        // Redis expires keys via TTL automatically — nothing to sweep.
+    }
 
-//     } catch (error) {
-//       console.error('Redis set error:', error);
-//     }
-//   }
+    async setMany(entries: Array<{ key: string; value: unknown; options?: CacheOptions }>): Promise<void> {
+        await Promise.all(entries.map(({ key, value, options }) => this.set(key, value as any, options)));
+    }
 
-//   async get(key: string): Promise<CacheEntry | undefined> {
-//     if (!this._client || !this.isConnected) {
-//       this.recordMiss();
-//       return undefined;
-//     }
+    async getMany(keys: string[]): Promise<Array<CacheEntry | undefined>> {
+        return Promise.all(keys.map(key => this.get(key)));
+    }
 
-//     try {
-//       const entryString = await this._client.get(key);
-//       if (!entryString) {
-//         this.recordMiss();
-//         return undefined;
-//       }
+    async deleteMany(keys: string[]): Promise<boolean[]> {
+        return Promise.all(keys.map(key => this.delete(key)));
+    }
 
-//       const entry: CacheEntry = JSON.parse(entryString);
+    private calculateSize(data: any): number {
+        try { return JSON.stringify(data).length * 2; } catch { return 0; }
+    }
 
-//       // Update hit count
-//       entry.Hits++;
-//       await this._client.setEx(key, Math.floor((entry.Ttl - (Date.now() - entry.Timestamp)) / 1000), JSON.stringify(entry));
-
-//       this.recordHit();
-//       return entry;
-//     } catch (error) {
-//       console.error('Redis get error:', error);
-//       this.recordMiss();
-//       return undefined;
-//     }
-//   }
-
-//   async has(key: string): Promise<boolean> {
-//     if (!this._client || !this.isConnected) {
-//       return false;
-//     }
-
-//     try {
-//       const exists = await this._client.exists(key);
-//       return exists === 1;
-//     } catch (error) {
-//       console.error('Redis has error:', error);
-//       return false;
-//     }
-//   }
-
-//   async delete(key: string): Promise<boolean> {
-//     if (!this._client || !this.isConnected) {
-//       return false;
-//     }
-
-//     try {
-//       // Get entry for metrics before deletion
-//       const entry = await this.get(key);
-
-//       const deleted = await this._client.del(key);
-
-//       if (deleted > 0 && entry) {
-//         this.updateMetrics(entry, 'remove');
-//       }
-
-//       return deleted > 0;
-//     } catch (error) {
-//       console.error('Redis delete error:', error);
-//       return false;
-//     }
-//   }
-
-//   async clear(): Promise<void> {
-//     if (!this._client || !this.isConnected) {
-//       return;
-//     }
-
-//     try {
-//       await this._client.flushAll();
-//       this.resetMetrics();
-//     } catch (error) {
-//       console.error('Redis clear error:', error);
-//     }
-//   }
-
-//   async findAndClear(searchPattern: string): Promise<string[]> {
-//     if (!this._client || !this.isConnected) {
-//       return [];
-//     }
-
-//     try {
-//       const keys = await this._client.keys(`*${searchPattern}*`);
-//       if (keys.length > 0) {
-//         await this._client.del(keys);
-
-//         // Update metrics (approximate since we can't get individual sizes easily)
-//         this.metrics.TotalEntries = Math.max(0, this.metrics.TotalEntries - keys.length);
-//       }
-//       return keys;
-//     } catch (error) {
-//       console.error('Redis findAndClear error:', error);
-//       return [];
-//     }
-//   }
-
-//   async getMetrics(): Promise<CacheMetrics> {
-//     if (!this._client || !this.isConnected) {
-//       return this.metrics;
-//     }
-
-//     try {
-//       // Update total entries from Redis
-//       const dbSize = await this._client.dbSize();
-//       this.metrics.TotalEntries = dbSize;
-
-//       this.updateHitRate();
-//       return { ...this.metrics };
-//     } catch (error) {
-//       console.error('Redis getMetrics error:', error);
-//       return this.metrics;
-//     }
-//   }
-
-//   async cleanup(): Promise<void> {
-//     // Redis handles TTL expiration automatically
-//     // This method can be used for custom cleanup logic if needed
-//     console.log('Redis cleanup: TTL-based expiration is automatic');
-//   }
-
-//   // Bulk operations
-//   async setMany(entries: Array<{ key: string; value: unknown; options?: CacheOptions }>): Promise<void> {
-//     if (!this._client || !this.isConnected) {
-//       return;
-//     }
-
-//     try {
-//       const pipeline = this._client.multi();
-
-//       for (const { key, value, options } of entries) {
-//         const ttl = Math.floor((options?.Ttl || this.config.DefaultTTL) / 1000);
-//         const entry: CacheEntry = {
-//           Data: value,
-//           Timestamp: Date.now(),
-//           Ttl: options?.Ttl || this.config.DefaultTTL,
-//           Hits: 0,
-//           Size: this.calculateSize(value),
-//         };
-
-//         pipeline.setEx(key, ttl, JSON.stringify(entry));
-
-//       }
-
-//       await pipeline.exec();
-//     } catch (error) {
-//       console.error('Redis setMany error:', error);
-//     }
-//   }
-
-//   async getMany(keys: string[]): Promise<Array<CacheEntry | undefined>> {
-//     if (!this._client || !this.isConnected) {
-//       return keys.map(() => undefined);
-//     }
-
-//     try {
-//       const results = await this._client.mGet(keys);
-//       return results.map(result => {
-//         if (result) {
-//           try {
-//             const entry: CacheEntry = JSON.parse(result);
-//             this.recordHit();
-//             return entry;
-//           } catch {
-//             this.recordMiss();
-//             return undefined;
-//           }
-//         } else {
-//           this.recordMiss();
-//           return undefined;
-//         }
-//       });
-//     } catch (error) {
-//       console.error('Redis getMany error:', error);
-//       return keys.map(() => undefined);
-//     }
-//   }
-
-//   async deleteMany(keys: string[]): Promise<boolean[]> {
-//     if (!this._client || !this.isConnected) {
-//       return keys.map(() => false);
-//     }
-
-//     try {
-//       const pipeline = this._client.multi();
-//       keys.forEach(key => pipeline.del(key));
-
-//       const results = await pipeline.exec();
-//       return results?.map(result => (result as any)?.[1] > 0) || keys.map(() => false);
-//     } catch (error) {
-//       console.error('Redis deleteMany error:', error);
-//       return keys.map(() => false);
-//     }
-//   }
-
-//   // Private helper methods
-//   private calculateSize(data: any): number {
-//     try {
-//       return JSON.stringify(data).length * 2; // UTF-16 estimate
-//     } catch {
-//       return 0;
-//     }
-//   }
-
-//   private recordHit(): void {
-//     if (this.config.EnableMetrics) {
-//       this.metrics.Hits++;
-//     }
-//   }
-
-//   private recordMiss(): void {
-//     if (this.config.EnableMetrics) {
-//       this.metrics.Misses++;
-//     }
-//   }
-
-//   private updateMetrics(entry: CacheEntry, action: 'add' | 'remove'): void {
-//     if (!this.config.EnableMetrics) return;
-
-//     if (action === 'add') {
-//       this.metrics.TotalSize += entry.Size;
-//       this.metrics.NewestEntry = entry.Timestamp;
-//     } else {
-//       this.metrics.TotalSize = Math.max(0, this.metrics.TotalSize - entry.Size);
-//     }
-
-//     this.metrics.AverageEntrySize = this.metrics.TotalEntries > 0
-//       ? this.metrics.TotalSize / this.metrics.TotalEntries
-//       : 0;
-//   }
-
-//   private updateHitRate(): void {
-//     const total = this.metrics.Hits + this.metrics.Misses;
-//     this.metrics.HitRate = total > 0 ? this.metrics.Hits / total : 0;
-//   }
-
-//   private resetMetrics(): void {
-//     this.metrics = {
-//       Hits: 0,
-//       Misses: 0,
-//       HitRate: 0,
-//       TotalSize: 0,
-//       TotalEntries: 0,
-//       OldestEntry: Date.now(),
-//       NewestEntry: Date.now(),
-//       AverageEntrySize: 0
-//     };
-//   }
-
-//   // Connection management
-//   async disconnect(): Promise<void> {
-//     if (this._client && this.isConnected) {
-//       await this._client.disconnect();
-//     }
-//   }
-
-//   isReady(): boolean {
-//     return this.isConnected;
-//   }
-// }
+}

--- a/src/modules/cache/request.response.cache.service.ts
+++ b/src/modules/cache/request.response.cache.service.ts
@@ -1,8 +1,8 @@
 import type { ICache } from './cache.interface';
 import type { CacheEntry, CacheMetrics, CacheOptions } from './cache.types';
 import { InMemoryCache } from './inmemory.cache';
+import { RedisCache } from './redis.cache';
 import { StrategyManager } from './cache.strategies';
-const REQUEST_CACHE_TYPE = 'InMemory';
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -11,12 +11,14 @@ export class RequestResponseCacheService {
     private static _cache: ICache = RequestResponseCacheService.getCache();
 
     private static getCache(): ICache {
-        if (REQUEST_CACHE_TYPE === 'InMemory') {
-            return new InMemoryCache();
+        // CACHE_PROVIDER=redis uses the shared Redis (survives restarts / works across
+        // replicas); anything else keeps the in-process in-memory cache.
+        if ((process.env.CACHE_PROVIDER || '').toLowerCase() === 'redis') {
+            console.log('RequestResponseCacheService: using Redis cache backend');
+            return new RedisCache();
         }
+        console.log('RequestResponseCacheService: using in-memory cache backend');
         return new InMemoryCache();
-
-        // return new RedisCache();
     }
 
     // Enhanced get with strategy support and stale-while-revalidate


### PR DESCRIPTION
## What
`src/connection/sequelizeClient.ts` hardcoded `dialect: 'mysql'` and `port: 3306`, so rean-bot-wrapper could not connect to the shared PostgreSQL. Now reads `DB_DIALECT` and `DB_PORT` from env (defaulting to the original mysql/3306 when unset), so the Helm chart's `DB_DIALECT=postgres` / `DB_PORT=5432` take effect. Models have no MySQL-specific column types, so no schema changes were needed.

## ⚠️ This alone does NOT make it deployable on the Postgres cluster
rean-bot-wrapper is **multi-tenant**: it opens a DB connection *per client*, loading each client's config (`DataBaseName`, etc.) from a **persistent cache** (`bot-secrets-<client>`) keyed by the client name in the URL path. To actually run it on-prem still needs:
1. **Redis + Elasticsearch** — the persistent-cache backends (`CACHE_*`, `ELASTICSEARCH_*`) it depends on; not currently in the cluster.
2. **Per-client config seeding** — the `bot-secrets-<client>` entries (incl. `DataBaseName`) must be populated.
3. Standard secret + database (like the other services).

So unlike reancare/bot-content, this is not a single-DB service and can't be "deployed directly." This PR is the code prerequisite; the infra + config are separate.